### PR TITLE
[REF] queue_job: enable state pause in jobs - t#46607

### DIFF
--- a/queue_job/job.py
+++ b/queue_job/job.py
@@ -18,6 +18,7 @@ ENQUEUED = "enqueued"
 DONE = "done"
 STARTED = "started"
 FAILED = "failed"
+PAUSED = "paused"
 
 STATES = [
     (PENDING, "Pending"),
@@ -25,6 +26,7 @@ STATES = [
     (STARTED, "Started"),
     (DONE, "Done"),
     (FAILED, "Failed"),
+    (PAUSED, "Paused"),
 ]
 
 DEFAULT_PRIORITY = 10  # used by the PriorityQueue to sort the jobs
@@ -677,6 +679,9 @@ class Job(object):
         self.state = FAILED
         if exc_info is not None:
             self.exc_info = exc_info
+
+    def set_paused(self):
+        self.state = PAUSED
 
     def __repr__(self):
         return "<Job %s, priority:%d>" % (self.uuid, self.priority)

--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -8,7 +8,7 @@ from odoo import _, api, exceptions, fields, models
 from odoo.osv import expression
 
 from ..fields import JobSerialized
-from ..job import DONE, PENDING, STATES, Job
+from ..job import DONE, PAUSED, PENDING, STATES, Job
 
 _logger = logging.getLogger(__name__)
 
@@ -222,6 +222,8 @@ class QueueJob(models.Model):
                 job_.set_done(result=result)
             elif state == PENDING:
                 job_.set_pending(result=result)
+            elif state == PAUSED:
+                job_.set_paused()
             else:
                 raise ValueError("State not supported: %s" % state)
             job_.store()
@@ -233,6 +235,10 @@ class QueueJob(models.Model):
 
     def requeue(self):
         self._change_job_state(PENDING)
+        return True
+
+    def pause(self):
+        self._change_job_state(PAUSED)
         return True
 
     def _message_post_on_failure(self):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

PR enables state `paused` in jobs, it doesn't allow execute job while job is that state.

Current behavior before PR:

Desired behavior after PR is merged:

-- I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

